### PR TITLE
Add more configuration options

### DIFF
--- a/@Dynamic Camo System/addons/core/XEH_init.sqf
+++ b/@Dynamic Camo System/addons/core/XEH_init.sqf
@@ -1,6 +1,18 @@
 
 // ADVANCED SETTINGS
 
+	// Base multiplier
+	// This modifies the camo result linearly
+	[
+		"DYNCAS_baseMultiplier",
+		"Slider",
+		["Camo multiplier", "The camo effectiveness multiplier"],
+		["Dynamic Camo System", "Advanced Settings"],
+		[0, 2, 1, 2],
+		nil,
+		{}
+	] call CBA_fnc_addSetting;
+
 	// Lower limit
 	// This is the minimum below which the camo coefficient can't go.
 	[

--- a/@Dynamic Camo System/addons/core/XEH_init.sqf
+++ b/@Dynamic Camo System/addons/core/XEH_init.sqf
@@ -37,6 +37,30 @@
 		{}
 	] call CBA_fnc_addSetting;
 
+	// Crouched effectiveness
+	// The amount your visibility is reduced when crouching
+	[
+		"DYNCAS_crouchReduction",
+		"Slider",
+		["Crouch Effectiveness", "How much your visibility is reduced when crouched"],
+		["Dynamic Camo System", "Advanced Settings"],
+		[0, 1, 0.05, 2],
+		nil,
+		{}
+	] call CBA_fnc_addSetting;
+
+	// Prone effectiveness
+	// The amount your visibility is reduced when proning
+	[
+		"DYNCAS_proneReduction",
+		"Slider",
+		["Prone Effectiveness", "How much your visibility is reduced when prone"],
+		["Dynamic Camo System", "Advanced Settings"],
+		[0, 1, 0.1, 2],
+		nil,
+		{}
+	] call CBA_fnc_addSetting;
+
 	// Run the script for
 	// Selects if the script should run for all players, player groups or all units
 	[

--- a/@Dynamic Camo System/addons/core/functions/fn_updateCamo.sqf
+++ b/@Dynamic Camo System/addons/core/functions/fn_updateCamo.sqf
@@ -80,6 +80,10 @@ private _result = 1.1 + ((sin(_val - 89.95))/2);
 // Multiplier
 _result = _result * DYNCAS_baseMultiplier;
 
+// Stance
+if (stance _unit == "CROUCH") then {_result = _result - DYNCAS_crouchReduction};
+if (stance _unit == "PRONE") then {_result = _result - DYNCAS_proneReduction};
+
 // Night compensation 2: electric boogaloo
 // Reduce visibility by 20% because camo doesn't matter as much at night
 if (DYNCAS_nightCompensation) then {

--- a/@Dynamic Camo System/addons/core/functions/fn_updateCamo.sqf
+++ b/@Dynamic Camo System/addons/core/functions/fn_updateCamo.sqf
@@ -77,6 +77,9 @@ _averages sort false;
 private _val = deg (pi * _averages # 0);
 private _result = 1.1 + ((sin(_val - 89.95))/2);
 
+// Multiplier
+_result = _result * DYNCAS_baseMultiplier;
+
 // Night compensation 2: electric boogaloo
 // Reduce visibility by 20% because camo doesn't matter as much at night
 if (DYNCAS_nightCompensation) then {


### PR DESCRIPTION
A base multiplier to allow users to change the final result of the camo - allows them to make camo overpowered, really weak, or fine-adjusted.

Made crouch and prone affect camo. This is configurable as well so it can be disabled if people don't like it or fine-adjusted.